### PR TITLE
feat: add playtime under game cover

### DIFF
--- a/FusionRetro_Local/Common.xaml
+++ b/FusionRetro_Local/Common.xaml
@@ -30,6 +30,17 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="BaseTextBlockStyleNoOver" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="{DynamicResource FontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource FontFamily}" />
+        <Setter Property="Foreground" Value="{DynamicResource IdleBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.4" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="GridIcon" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" >
         <Setter Property="Margin" Value="0,5,8,0" />
         <Setter Property="Foreground" Value="{DynamicResource PromptBrush}" />

--- a/FusionRetro_Local/Constants.xaml
+++ b/FusionRetro_Local/Constants.xaml
@@ -8,7 +8,8 @@
     <sys:Boolean x:Key="GridViewImageCoverUseRoundedCorners">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewImageCoverShowPlatformBanner">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewListShowFavorite">True</sys:Boolean>
-    
+    <sys:Boolean x:Key="GridViewListShowPlayTime">False</sys:Boolean>
+
     <sys:Boolean x:Key="DetailViewDetailInfoIcon">True</sys:Boolean>
     <sys:Boolean x:Key="DetailViewRatingStar">True</sys:Boolean>
 

--- a/FusionRetro_Local/DerivedStyles/GridViewItemStyle.xaml
+++ b/FusionRetro_Local/DerivedStyles/GridViewItemStyle.xaml
@@ -28,13 +28,53 @@
                                 </Border.Style>
                             </Border>
                         </Grid>
-                        <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
-                                   Style="{DynamicResource BaseTextBlockStyle}"                                                                   
-                                   TextAlignment="Center" TextTrimming="CharacterEllipsis"
-                                   VerticalAlignment="Bottom"
-                                   Padding="2,8,2,8"
-                                   Width="{Settings GridItemWidth}" 
-                                   Visibility="{Settings ShowNamesUnderCovers}" />
+
+                        <StackPanel HorizontalAlignment="Center" Tag="{DynamicResource GridViewListShowPlayTime}">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Margin" Value="0,0,0,0" />
+                                    <!-- APPLY MARGIN ONLY IF HAS GAME NAME OR PLAY TIME -->
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Tag, RelativeSource={RelativeSource Self}}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+
+                            <!-- GAME NAME -->
+                            <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
+                                    Style="{DynamicResource BaseTextBlockStyle}"
+                                    TextAlignment="Center" TextTrimming="CharacterEllipsis"
+                                    VerticalAlignment="Bottom"
+                                    Width="{Settings GridItemWidth}" 
+                                    Visibility="{Settings ShowNamesUnderCovers}" />
+
+                            <!-- PLAY TIME -->
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
+                                        Tag="{DynamicResource GridViewListShowPlayTime}"
+                                        Visibility="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Style.Triggers>
+                                            <!-- MARGIN TOP IF HAS GAME NAME -->
+                                            <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                                <Setter Property="Margin" Value="0,4,0,0" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Text="&#xed5a;" FontSize="{DynamicResource FontSize}"
+                                        Style="{DynamicResource IconFontStyle}"
+                                        Margin="0,0,2,0" />
+                                <TextBlock x:Name="GamePlaytime" Text="{Binding Playtime, Converter={StaticResource PlayTimeToStringConverter}}" FontSize="{DynamicResource FontSizeSmall}"
+                                        Style="{DynamicResource BaseTextBlockStyleNoOver}" />
+                            </StackPanel>
+                        </StackPanel>
                     </StackPanel>
                     
                     <ControlTemplate.Triggers>

--- a/FusionRetro_Local/thememodifier.yaml
+++ b/FusionRetro_Local/thememodifier.yaml
@@ -5,5 +5,6 @@ Constants:
     - DetailViewRatingStar: 'Show Rating Star under game name'
     - "Grid View Covers"
     - GridViewListShowFavorite: 'Show favorites icon'
+    - GridViewListShowPlayTime: 'Show play time under Game Cover'
     - GridViewImageCoverShowPlatformBanner: 'Show platform banners ("ThemeExtras" extension needed)'
     - GridViewImageCoverUseRoundedCorners: 'Use rounded corners on game image covers (May reduce app performance)'

--- a/FusionX_Local0430/Common.xaml
+++ b/FusionX_Local0430/Common.xaml
@@ -30,6 +30,17 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="BaseTextBlockStyleNoOver" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="{DynamicResource FontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource FontFamily}" />
+        <Setter Property="Foreground" Value="{DynamicResource IdleBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.4" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="GridIcon" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" >
         <Setter Property="Margin" Value="0,5,8,0" />
         <Setter Property="Foreground" Value="{DynamicResource PromptBrush}" />

--- a/FusionX_Local0430/Constants.xaml
+++ b/FusionX_Local0430/Constants.xaml
@@ -13,6 +13,7 @@
     <sys:Boolean x:Key="GridViewImageCoverUseRoundedCorners">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewImageCoverShowPlatformBanner">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewListShowFavorite">True</sys:Boolean>
+    <sys:Boolean x:Key="GridViewListShowPlayTime">False</sys:Boolean>
     <sys:Boolean x:Key="GridViewVideoOnByDefault">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewVideoWindowedByDefault">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewVideoAlternative">False</sys:Boolean>

--- a/FusionX_Local0430/DerivedStyles/GridViewItemStyle.xaml
+++ b/FusionX_Local0430/DerivedStyles/GridViewItemStyle.xaml
@@ -28,13 +28,53 @@
                                 </Border.Style>
                             </Border>
                         </Grid>
-                        <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
-                                   Style="{DynamicResource BaseTextBlockStyle}"                                                                   
-                                   TextAlignment="Center" TextTrimming="CharacterEllipsis"
-                                   VerticalAlignment="Bottom"
-                                   Padding="2,8,2,8"
-                                   Width="{Settings GridItemWidth}" 
-                                   Visibility="{Settings ShowNamesUnderCovers}" />
+
+                        <StackPanel HorizontalAlignment="Center" Tag="{DynamicResource GridViewListShowPlayTime}">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Margin" Value="0,0,0,0" />
+                                    <!-- APPLY MARGIN ONLY IF HAS GAME NAME OR PLAY TIME -->
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Tag, RelativeSource={RelativeSource Self}}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+
+                            <!-- GAME NAME -->
+                            <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
+                                    Style="{DynamicResource BaseTextBlockStyle}"
+                                    TextAlignment="Center" TextTrimming="CharacterEllipsis"
+                                    VerticalAlignment="Bottom"
+                                    Width="{Settings GridItemWidth}" 
+                                    Visibility="{Settings ShowNamesUnderCovers}" />
+
+                            <!-- PLAY TIME -->
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
+                                        Tag="{DynamicResource GridViewListShowPlayTime}"
+                                        Visibility="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Style.Triggers>
+                                            <!-- MARGIN TOP IF HAS GAME NAME -->
+                                            <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                                <Setter Property="Margin" Value="0,4,0,0" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Text="&#xed5a;" FontSize="{DynamicResource FontSize}"
+                                        Style="{DynamicResource IconFontStyle}"
+                                        Margin="0,0,2,0" />
+                                <TextBlock x:Name="GamePlaytime" Text="{Binding Playtime, Converter={StaticResource PlayTimeToStringConverter}}" FontSize="{DynamicResource FontSizeSmall}"
+                                        Style="{DynamicResource BaseTextBlockStyleNoOver}" />
+                            </StackPanel>
+                        </StackPanel>
                     </StackPanel>
                     
                     <ControlTemplate.Triggers>

--- a/FusionX_Local0430/thememodifier.yaml
+++ b/FusionX_Local0430/thememodifier.yaml
@@ -8,6 +8,7 @@ Constants:
     - "Grid View"
     - DetailsViewGameOverviewMaxWidth(800,2400): 'Maximum width of DetailViewGameOverview in Grid View'
     - GridViewListShowFavorite: 'Show favorites icon on Game Cover'
+    - GridViewListShowPlayTime: 'Show play time under Game Cover'
     - GridViewImageCoverShowPlatformBanner: 'Show platform banners ("ThemeExtras" extension needed)'
     - GridViewImageCoverUseRoundedCorners: 'Use rounded corners on game image covers (May reduce app performance)'
     - GridViewEnableCoverShineAnimation: 'Enable cover highlight animation on hover'

--- a/FusionY_Local/Common.xaml
+++ b/FusionY_Local/Common.xaml
@@ -30,6 +30,17 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="BaseTextBlockStyleNoOver" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="{DynamicResource FontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource FontFamily}" />
+        <Setter Property="Foreground" Value="{DynamicResource IdleBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.4" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="GridIcon" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" >
         <Setter Property="Margin" Value="0,5,8,0" />
         <Setter Property="Foreground" Value="{DynamicResource PromptBrush}" />

--- a/FusionY_Local/Constants.xaml
+++ b/FusionY_Local/Constants.xaml
@@ -8,7 +8,8 @@
     <sys:Boolean x:Key="GridViewImageCoverUseRoundedCorners">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewImageCoverShowPlatformBanner">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewListShowFavorite">True</sys:Boolean>
-    
+    <sys:Boolean x:Key="GridViewListShowPlayTime">False</sys:Boolean>
+
     <sys:Boolean x:Key="DetailViewDetailInfoIcon">True</sys:Boolean>
     <sys:Boolean x:Key="DetailViewRatingStar">True</sys:Boolean>
 

--- a/FusionY_Local/DerivedStyles/GridViewItemStyle.xaml
+++ b/FusionY_Local/DerivedStyles/GridViewItemStyle.xaml
@@ -28,13 +28,53 @@
                                 </Border.Style>
                             </Border>
                         </Grid>
-                        <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
-                                   Style="{DynamicResource BaseTextBlockStyle}"                                                                   
-                                   TextAlignment="Center" TextTrimming="CharacterEllipsis"
-                                   VerticalAlignment="Bottom"
-                                   Padding="2,8,2,8"
-                                   Width="{Settings GridItemWidth}" 
-                                   Visibility="{Settings ShowNamesUnderCovers}" />
+
+                        <StackPanel HorizontalAlignment="Center" Tag="{DynamicResource GridViewListShowPlayTime}">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Margin" Value="0,0,0,0" />
+                                    <!-- APPLY MARGIN ONLY IF HAS GAME NAME OR PLAY TIME -->
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Tag, RelativeSource={RelativeSource Self}}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+
+                            <!-- GAME NAME -->
+                            <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
+                                    Style="{DynamicResource BaseTextBlockStyle}"
+                                    TextAlignment="Center" TextTrimming="CharacterEllipsis"
+                                    VerticalAlignment="Bottom"
+                                    Width="{Settings GridItemWidth}" 
+                                    Visibility="{Settings ShowNamesUnderCovers}" />
+
+                            <!-- PLAY TIME -->
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
+                                        Tag="{DynamicResource GridViewListShowPlayTime}"
+                                        Visibility="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Style.Triggers>
+                                            <!-- MARGIN TOP IF HAS GAME NAME -->
+                                            <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                                <Setter Property="Margin" Value="0,4,0,0" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Text="&#xed5a;" FontSize="{DynamicResource FontSize}"
+                                        Style="{DynamicResource IconFontStyle}"
+                                        Margin="0,0,2,0" />
+                                <TextBlock x:Name="GamePlaytime" Text="{Binding Playtime, Converter={StaticResource PlayTimeToStringConverter}}" FontSize="{DynamicResource FontSizeSmall}"
+                                        Style="{DynamicResource BaseTextBlockStyleNoOver}" />
+                            </StackPanel>
+                        </StackPanel>
                     </StackPanel>
                     
                     <ControlTemplate.Triggers>

--- a/FusionY_Local/thememodifier.yaml
+++ b/FusionY_Local/thememodifier.yaml
@@ -5,5 +5,6 @@ Constants:
     - DetailViewRatingStar: 'Show Rating Star under game name'
     - "Grid View Covers"
     - GridViewListShowFavorite: 'Show favorites icon'
+    - GridViewListShowPlayTime: 'Show play time under Game Cover'
     - GridViewImageCoverShowPlatformBanner: 'Show platform banners ("ThemeExtras" extension needed)'
     - GridViewImageCoverUseRoundedCorners: 'Use rounded corners on game image covers (May reduce app performance)'

--- a/Source/Common.xaml
+++ b/Source/Common.xaml
@@ -30,6 +30,17 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="BaseTextBlockStyleNoOver" TargetType="TextBlock">
+        <Setter Property="FontSize" Value="{DynamicResource FontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource FontFamily}" />
+        <Setter Property="Foreground" Value="{DynamicResource IdleBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="0.4" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
     <Style x:Key="GridIcon" TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" >
         <Setter Property="Margin" Value="0,5,8,0" />
         <Setter Property="Foreground" Value="{DynamicResource PromptBrush}" />

--- a/Source/Constants.xaml
+++ b/Source/Constants.xaml
@@ -11,6 +11,7 @@
     <sys:Boolean x:Key="GridViewImageCoverUseRoundedCorners">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewImageCoverShowPlatformBanner">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewListShowFavorite">True</sys:Boolean>
+    <sys:Boolean x:Key="GridViewListShowPlayTime">False</sys:Boolean>
     <sys:Boolean x:Key="GridViewVideoOnByDefault">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewVideoWindowedByDefault">True</sys:Boolean>
     <sys:Boolean x:Key="GridViewVideoAlternative">False</sys:Boolean>

--- a/Source/DerivedStyles/GridViewItemStyle.xaml
+++ b/Source/DerivedStyles/GridViewItemStyle.xaml
@@ -28,13 +28,53 @@
                                 </Border.Style>
                             </Border>
                         </Grid>
-                        <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
-                                   Style="{DynamicResource BaseTextBlockStyle}"                                                                   
-                                   TextAlignment="Center" TextTrimming="CharacterEllipsis"
-                                   VerticalAlignment="Bottom"
-                                   Padding="2,8,2,8"
-                                   Width="{Settings GridItemWidth}" 
-                                   Visibility="{Settings ShowNamesUnderCovers}" />
+
+                        <StackPanel HorizontalAlignment="Center" Tag="{DynamicResource GridViewListShowPlayTime}">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Margin" Value="0,0,0,0" />
+                                    <!-- APPLY MARGIN ONLY IF HAS GAME NAME OR PLAY TIME -->
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                        <DataTrigger Binding="{Binding Tag, RelativeSource={RelativeSource Self}}" Value="True">
+                                            <Setter Property="Margin" Value="2,8,2,8" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+
+                            <!-- GAME NAME -->
+                            <TextBlock x:Name="GameName" Text="{Binding DisplayName}" FontSize="{DynamicResource FontSizeSmall}"
+                                    Style="{DynamicResource BaseTextBlockStyle}"
+                                    TextAlignment="Center" TextTrimming="CharacterEllipsis"
+                                    VerticalAlignment="Bottom"
+                                    Width="{Settings GridItemWidth}" 
+                                    Visibility="{Settings ShowNamesUnderCovers}" />
+
+                            <!-- PLAY TIME -->
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center"
+                                        Tag="{DynamicResource GridViewListShowPlayTime}"
+                                        Visibility="{Binding Tag, RelativeSource={RelativeSource Self}, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Margin" Value="0,0,0,0" />
+                                        <Style.Triggers>
+                                            <!-- MARGIN TOP IF HAS GAME NAME -->
+                                            <DataTrigger Binding="{Settings ShowNamesUnderCovers}" Value="True">
+                                                <Setter Property="Margin" Value="0,4,0,0" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock Text="&#xed5a;" FontSize="{DynamicResource FontSize}"
+                                        Style="{DynamicResource IconFontStyle}"
+                                        Margin="0,0,2,0" />
+                                <TextBlock x:Name="GamePlaytime" Text="{Binding Playtime, Converter={StaticResource PlayTimeToStringConverter}}" FontSize="{DynamicResource FontSizeSmall}"
+                                        Style="{DynamicResource BaseTextBlockStyleNoOver}" />
+                            </StackPanel>
+                        </StackPanel>
                     </StackPanel>
                     
                     <ControlTemplate.Triggers>

--- a/Source/thememodifier.yaml
+++ b/Source/thememodifier.yaml
@@ -8,6 +8,7 @@ Constants:
     - "Grid View"
     - DetailsViewGameOverviewMaxWidth(800,2400): 'Maximum width of DetailViewGameOverview in Grid View'
     - GridViewListShowFavorite: 'Show favorites icon on Game Cover'
+    - GridViewListShowPlayTime: 'Show play time under Game Cover'
     - GridViewImageCoverShowPlatformBanner: 'Show platform banners ("ThemeExtras" extension needed)'
     - GridViewImageCoverUseRoundedCorners: 'Use rounded corners on game image covers (May reduce app performance)'
     - "Video Control in Detail View"


### PR DESCRIPTION
Add option to show play time under game cover, `false` by default so nothing changes until user toggles with on the ThemeModifier settings.

- New constant `GridViewListShowPlayTime`.
- Added a new base style without trigger to change color on hover.
- Wrapped the game name with a StackPanel with dynamic margin based on the game name and play time visibilities.
- Play time also has a small dynamic margin based on game name visibility.

With name and playtime:
![image](https://github.com/user-attachments/assets/ac6a462c-e9c9-402c-b5b2-5a4a584cd666)

With name only:
![image](https://github.com/user-attachments/assets/8b244d5b-68dd-4b9a-9a00-0f68727fb138)

With playtime only:
![image](https://github.com/user-attachments/assets/def9f221-95b9-491f-88e7-8a7600eb7c5a)

Without both:
![image](https://github.com/user-attachments/assets/d5574170-f67f-4578-9e27-b0a90daa23cd)
